### PR TITLE
Make sure Macs do not try to track .DS_STORE files in git repos

### DIFF
--- a/home_dir/gitconfig
+++ b/home_dir/gitconfig
@@ -2,6 +2,7 @@
 	helper = cache --timeout=3600
 [core]
 	autocrlf = input
+	excludesfile = /Users/weitzner/.gitignore_global
 [push]
 	default = simple
 [filter "lfs"]

--- a/home_dir/gitconfig
+++ b/home_dir/gitconfig
@@ -2,7 +2,6 @@
 	helper = cache --timeout=3600
 [core]
 	autocrlf = input
-	excludesfile = /Users/weitzner/.gitignore_global
 [push]
 	default = simple
 [filter "lfs"]

--- a/home_dir/gitignore_global
+++ b/home_dir/gitignore_global
@@ -1,0 +1,1 @@
+.DS_Store

--- a/symlink_dotfiles.sh
+++ b/symlink_dotfiles.sh
@@ -61,4 +61,5 @@ if [[ ${#KEY_ID} -gt 0 ]]; then
     git config --global commit.gpgsign true
 fi
 
+git config --global core.excludesfile $HOME/.gitignore_global
 echo "Test out your configurations and, if it all looks good, delete" $old_dir


### PR DESCRIPTION
Turning this
```
± git status
On branch master
Your branch is up-to-date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.DS_Store
	some_dir/.DS_Store
```

into this
```
± git status
On branch master
Your branch is up-to-date with 'origin/master'.

nothing to commit, working tree clean
```

with a global `.gitignore` file that is configured when the `symlink_dotfiles.sh` script is executed.