### PR TITLE
Updates to gitignore and setup script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 pymol_scripts/pymol_license.lic
 pymol_scripts/__pycache__
 pymol_scripts/*.pyc

--- a/symlink_dotfiles.sh
+++ b/symlink_dotfiles.sh
@@ -24,6 +24,9 @@ link_dotfile ()
     if [[ -f $1 ]]; then
         echo "Moving existing dotfile ($1) to $old_dir"
         mv $1 $old_dir/$3
+    elif [[ -L $1 ]]; then
+        echo "Removing existing link to dotfile ($1)"
+        unlink $1
     fi
     echo "Creating symlink to $1 in home directory.\n"
     ln -s $2 $1


### PR DESCRIPTION
The setup script can now detect symlinks from previous executions and handle that well. Useful if you rename the directory the repo is cloned into.