### PR TITLE
Updating direnvrc and zshrc for conda v>=4.4

### DIFF
--- a/home_dir/direnvrc
+++ b/home_dir/direnvrc
@@ -7,6 +7,8 @@
 
 
 layout_conda() {
+  \. "$HOME/miniconda3/etc/profile.d/conda.sh" || return $?
+
   if [ -n "${1}" ]; then
     NAME="${1}"
   else
@@ -17,7 +19,7 @@ layout_conda() {
   if [ -n "${NAME}" ]; then
     ACTIVATE_ARGS="${NAME}"
     CREATE_ARGS="-n ${NAME}"
-    if [ "${NAME}" != `conda env list | grep "${NAME}" | awk '{print $1}'` ]; then
+    if [[ "${NAME}" != `conda env list | grep "${NAME}" | awk '{print $1}'` ]]; then
       CREATE_NEW_ENV=true
     fi
   else
@@ -32,6 +34,5 @@ layout_conda() {
   if [ "${CREATE_NEW_ENV}" = true ]; then
     conda create ${CREATE_ARGS}
   fi
-  source activate ${ACTIVATE_ARGS}
+  conda activate ${ACTIVATE_ARGS}
 }
-

--- a/home_dir/zshrc
+++ b/home_dir/zshrc
@@ -6,7 +6,7 @@ ZSH=$HOME/.oh-my-zsh
 ZSH_THEME="verbose"
 
 # Customize to your needs...
-PATH_PREFIX=$HOME/miniconda3/bin:$HOME/bin
+PATH_PREFIX=$HOME/bin
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     # Oh my, zsh plugins
@@ -24,6 +24,7 @@ if [[ -n ${TMUX} || ${OSTYPE} == "linux-gnu" ]]; then
 fi
 
 source $ZSH/oh-my-zsh.sh
+export PROMPT
 
 # Allow things like "sudo !!" to work without the shell wanting confirmation
 setopt no_hist_verify
@@ -77,9 +78,6 @@ fi
 
 export PATH=$PATH_PREFIX:$PATH
 
-# enable directory-based environment activation and switching
-eval "$(direnv hook zsh)"
-
 # set up alias hub -> git if `hub` is installed on the system
 if type hub &> /dev/null; then
     eval "$(hub alias -s)"
@@ -94,3 +92,23 @@ alias ll='ls -hlt'
 # Baker lab machines
 alias digs="ssh digs"
 alias jojo="ssh jojo"
+
+# >>> conda initialize >>>
+# !! Contents within this block are managed by 'conda init' !!
+__conda_setup="$($HOME'/miniconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
+if [ $? -eq 1 ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        . "$HOME/miniconda3/etc/profile.d/conda.sh"
+        export PATH="$HOME/miniconda3/bin:$PATH"
+        conda activate base
+    else
+        export PATH="$HOME/miniconda3/bin:$PATH"
+    fi
+fi
+unset __conda_setup
+# <<< conda initialize <<<
+
+# enable directory-based environment activation and switching
+eval "$(direnv hook zsh)"


### PR DESCRIPTION
This change makes conda, direnv and zsh work with each other when using recent versions of conda. There is another change that needs to be made in the conda config for this work as intended:

In `⁨miniconda3⁩/lib⁩/python3.7⁩/site-packages⁩/conda⁩/activate.py` lines 625 and 638, change `PS1` to `PROMPT` so the lines are:

625: `ps1 = self.environ.get('PROMPT', '')`
638: `'PROMPT': conda_prompt_modifier + ps1,`